### PR TITLE
Update the deprecated validation params for lower bound validation

### DIFF
--- a/res/stomp_moveit.yaml
+++ b/res/stomp_moveit.yaml
@@ -4,7 +4,7 @@ stomp_moveit:
     description: "Total number of iterations that STOMP is allowed to run",
     default_value: 1000,
     validation: {
-      lower_bounds<>: [1]
+      gt_eq<>: [1]
     }
   }
   num_iterations_after_valid: {
@@ -12,7 +12,7 @@ stomp_moveit:
     description: "Total number of iterations that STOMP should continue optimizing an already valid solution",
     default_value: 0,
     validation: {
-      lower_bounds<>: [0]
+      gt_eq<>: [0]
     }
   }
   num_rollouts: {
@@ -20,7 +20,7 @@ stomp_moveit:
     description: "Number of noisy trajectories that are being generated for each iteration",
     default_value: 15,
     validation: {
-      lower_bounds<>: [1]
+      gt_eq<>: [1]
     }
   }
   max_rollouts: {
@@ -28,7 +28,7 @@ stomp_moveit:
     description: "Combined number of old and new rollouts that are being processed for each iteration",
     default_value: 25,
     validation: {
-      lower_bounds<>: [1]
+      gt_eq<>: [1]
     }
   }
   num_timesteps: {
@@ -36,7 +36,7 @@ stomp_moveit:
     description: "Number of timesteps used in trajectories - corresponds to waypoint count",
     default_value: 40,
     validation: {
-      lower_bounds<>: [3]
+      gt_eq<>: [3]
     }
   }
   exponentiated_cost_sensitivity: {
@@ -44,7 +44,7 @@ stomp_moveit:
     description: "Exponentiated cost sensitivity coefficient used for probability calculation",
     default_value: 0.5,
     validation: {
-      lower_bounds<>: [0.0]
+      gt_eq<>: [0.0]
     }
   }
   control_cost_weight: {


### PR DESCRIPTION
# Description

When trying to build the repository, we obtain the error 
`error: ‘lower_bounds’ was not declared in this scope; did you mean ‘rsl::lower_bounds’?`
This is due to automatic ros parameter generation using yaml files using the [generate parameter library by PickNikRobotics](https://github.com/PickNikRobotics/generate_parameter_library#built-in-validators). 
To fix the issue, the previously used parameter for validation, **lower_bounds<>**, which is now deprecated, is replaced by **gt_eq<>** .

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] A clean build is performed
- [x] Using the maurob_demo repository, which uses this repository as submodule, the "Simulation with Mock Robot Hardware and Mock Gripper" demo is ran